### PR TITLE
Add support for windows-2022

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-2016, macos-latest ]
+        os: [ ubuntu-latest, windows-2016, macos-latest, windows-2022 ]
         node: [ "12.0.0", "14.0.0", "15.0.0", "16.0.0", "17.0.0" ]
         task: [ test ]
 
@@ -25,6 +25,9 @@ jobs:
       - name: Configure msvs version on Windows
         if: ${{matrix.os == 'windows-2016'}}
         run: npm config set msvs_version 2017
+      - name: Configure msvs version on Windows
+        if: ${{matrix.os == 'windows-2022'}}
+        run: npm config set msvs_version 2022
       - name: Run tests
         env:
           OPENCV4NODEJS_DISABLE_AUTOBUILD: 1

--- a/.github/workflows/tagged_release.yaml
+++ b/.github/workflows/tagged_release.yaml
@@ -8,7 +8,7 @@ jobs:
   prebuild-node:
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-2016, macos-latest ]
+        os: [ ubuntu-latest, windows-2016, macos-latest, windows-2022 ]
         node: [ 14]
         task: [ prebuild ]
         runtime: [ node ]
@@ -24,6 +24,9 @@ jobs:
       - name: Configure msvs version on Windows
         if: ${{matrix.os == 'windows-2016'}}
         run: npm config set msvs_version 2017
+      - name: Configure msvs version on Windows
+        if: ${{matrix.os == 'windows-2022'}}
+        run: npm config set msvs_version 2022
       - name: Install
         run: npm ci --unsafe-perm
       - name: Publish prebuild
@@ -33,7 +36,7 @@ jobs:
   prebuild-electron:
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-2016, macos-latest ]
+        os: [ ubuntu-latest, windows-2016, macos-latest, windows-2022 ]
         node: [ 14 ]
         task: [ prebuild ]
         runtime: [ electron ]
@@ -49,6 +52,9 @@ jobs:
       - name: Configure msvs version on Windows
         if: ${{matrix.os == 'windows-2016'}}
         run: npm config set msvs_version 2017
+      - name: Configure msvs version on Windows
+        if: ${{matrix.os == 'windows-2022'}}
+        run: npm config set msvs_version 2022
       - name: Install
         run: npm ci --unsafe-perm
       - name: Publish prebuild


### PR DESCRIPTION
This is very untested I'm afraid as running the actions on my fork seems to fail pretty hard on unrelated things
https://github.com/kokarn/opencv4nodejs/actions/workflows/ci.yaml

Should solve https://github.com/nut-tree/nut.js/issues/328