### PR TITLE
Fix: Webpacked electron app can't load native module on windows

### DIFF
--- a/lib/cv.js
+++ b/lib/cv.js
@@ -1,14 +1,29 @@
 const path = require('path');
 const { resolvePath } = require('./commons');
 
-const requirePath = path.join(__dirname, process.env.BINDINGS_DEBUG ? '../build/Debug/opencv4nodejs' : '../build/Release/opencv4nodejs')
+const isElectron = process.versions.hasOwnProperty('electron')
+const packagePath = 'node_modules/opencv4nodejs-prebuilt'
 
-const logDebug = process.env.OPENCV4NODES_DEBUG_REQUIRE ? require('npmlog').info : () => {}
-
+const debugOrRelease = process.env.BINDINGS_DEBUG ? 'Debug' : 'Release'
+const binaryName = 'opencv4nodejs.node'
+let requirePath
 let cv = null
+let requireFunc
+const logDebug = process.env.OPENCV4NODES_DEBUG_REQUIRE ? require('npmlog').info : () => {}
 try {
-  logDebug('require', 'require path is ' + requirePath)
-  cv = require(requirePath);
+  if (isElectron) {
+    // in electron we are referencing the node module from a packed file in some static folder. So relative path will be complicated. Use absolute path instead.
+    const electron = require("electron")
+    const appPath = (electron.app || electron.remote.app).getAppPath()
+    requirePath = path.resolve(appPath, packagePath, `build/${debugOrRelease}/${binaryName}`)
+    // requireing a .node file fails with webpack. __non_webpack_require__ tells webpack not to resolve the dependency
+    logDebug('require', 'require path is ' + requirePath)
+    cv = __non_webpack_require__(requirePath);
+  } else {
+    requirePath = path.join(__dirname, `../build/${debugOrRelease}/${binaryName}`)
+    logDebug('require', 'require path is ' + requirePath)
+    cv = require(requirePath);
+  }
 } catch (err) {
   logDebug('require', 'failed to require cv with exception: ' + err.toString())
   throw err


### PR DESCRIPTION
This fixed the import problem on windows for me. 